### PR TITLE
get workflow annotation from galaxy directly

### DIFF
--- a/includes/tripal_galaxy.webform.inc
+++ b/includes/tripal_galaxy.webform.inc
@@ -54,6 +54,10 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
   $steps = $workflow['steps'];
   foreach ($steps as $step_index => $step) {
 
+    $step_annotation = '';
+    if (isset($step['annotation'])) {
+      $step_annotation = $step['annotation'];
+    }
     // Each step is contained in a fieldset. We'll name the field set after
     // it's step and if a tool is present we'll include the tool info.
     $cid = count($webform->components) + 1;
@@ -69,7 +73,7 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
       'type' => 'fieldset',
       'value' => '',
       'extra' => [
-        'description' => '',
+        'description' => $step_annotation,
         'description_above' => 1,
         'private' => 0,
         'css_classes' => 'tripal-galaxy-fieldset',
@@ -166,7 +170,7 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
         // We want to change the name of the fieldset to have the name of
         // the tool.
         // we also want to add tool description to the end, like what we see in Galaxy.
-        $fieldset_name .= ': ' . $tool['name'] . ' ' . $tool['description'] . ' (Galaxy Version ' . $tool['version'] . ')';
+        $fieldset_name .= ': ' . $tool['name'] . ' (Galaxy Version ' . $tool['version'] . ')';
         $webform->components[$fieldset_cid - 1]['name'] = $fieldset_name;
 
 

--- a/theme/css/tripal_galaxy.css
+++ b/theme/css/tripal_galaxy.css
@@ -23,3 +23,7 @@
   white-space: nowrap;
   overflow: hidden;
 }
+
+.tripal-galaxy-fieldset .fieldset-description {
+  color: #0099ff;
+}


### PR DESCRIPTION
This PR is the solution for getting annotation (messages to guide users) for each step directly from Galaxy workflows, so that tripal sites use the same workflows don't need to add workflow annotations again and again.

<img width="750" alt="screen shot 2018-03-25 at 12 01 51 pm" src="https://user-images.githubusercontent.com/1262709/37877274-84bb9436-3026-11e8-8a6a-0afed0d1c501.png">

I also removed the tool description from the fieldset title. Only the tool name and tool version is kept. I added tool description on the instruction page. Since each step of a workflow has annotation message (should have), tool description information is not very necessary.

<img width="736" alt="screen shot 2018-03-25 at 12 16 54 pm" src="https://user-images.githubusercontent.com/1262709/37877282-9877acbc-3026-11e8-924d-caebd52d6493.png">


