### PR TITLE
Disable export/import workflow

### DIFF
--- a/includes/tripal_galaxy.webform.inc
+++ b/includes/tripal_galaxy.webform.inc
@@ -54,6 +54,10 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
   $steps = $workflow['steps'];
   foreach ($steps as $step_index => $step) {
 
+    $step_annotation = '';
+    if (isset($step['annotation'])) {
+      $step_annotation = $step['annotation'];
+    }
     // Each step is contained in a fieldset. We'll name the field set after
     // it's step and if a tool is present we'll include the tool info.
     $cid = count($webform->components) + 1;
@@ -69,7 +73,7 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
       'type' => 'fieldset',
       'value' => '',
       'extra' => [
-        'description' => '',
+        'description' => $step_annotation,
         'description_above' => 1,
         'private' => 0,
         'css_classes' => 'tripal-galaxy-fieldset',
@@ -166,7 +170,7 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
         // We want to change the name of the fieldset to have the name of
         // the tool.
         // we also want to add tool description to the end, like what we see in Galaxy.
-        $fieldset_name .= ': ' . $tool['name'] . ' ' . $tool['description'] . ' (Galaxy Version ' . $tool['version'] . ')';
+        $fieldset_name .= ': ' . $tool['name'] . ' (Galaxy Version ' . $tool['version'] . ')';
         $webform->components[$fieldset_cid - 1]['name'] = $fieldset_name;
 
 

--- a/theme/css/tripal_galaxy.css
+++ b/theme/css/tripal_galaxy.css
@@ -23,3 +23,7 @@
   white-space: nowrap;
   overflow: hidden;
 }
+
+.tripal-galaxy-fieldset .fieldset-description {
+  color: #0099ff;
+}

--- a/tripal_galaxy.module
+++ b/tripal_galaxy.module
@@ -454,31 +454,6 @@ function tripal_galaxy_menu() {
 
 
 /**
- * Implements hook_menu_alter().
- */
-function tripal_galaxy_menu_alter(&$items) {
-  $items['node/%webform_menu/webform/export-workflow'] = [
-    'title' => 'Export',
-    'page callback' => 'export_tripal_galaxy_workflow',
-    'page arguments' => [1],
-    'access arguments' => ['access content'],
-    'weight' => 9,
-    'type' => MENU_LOCAL_TASK,
-  ];
-  $items['node/%webform_menu/webform/import-workflow'] = [
-    'title' => 'Import',
-    'page callback' => 'import_tripal_galaxy_workflow',
-    'page arguments' => [1],
-    'access arguments' => ['access content'],
-    'weight' => 10,
-    'type' => MENU_LOCAL_TASK,
-    'file' => 'includes/tripal_galaxy.import_webform.form.inc',
-    'file path' => drupal_get_path('module', 'tripal_galaxy'),
-  ];
-}
-
-
-/**
  * Implements hook_admin_paths_alter().
  */
 function tripal_galaxy_admin_paths_alter(&$paths) {
@@ -1856,63 +1831,6 @@ function tripal_galaxy_results_download($proxy_id) {
   exit();
 }
 
-
-/**
- * @param $node
- *
- * a page callback to export galaxy webform as a json file.
- */
-function export_tripal_galaxy_workflow($node) {
-
-  $webform = json_encode($node->webform);
-
-  drupal_add_http_header('Content-Type', 'application/json');
-  drupal_add_http_header('Content-Disposition', 'attachment; filename="webform-' . $node->type . '-' . $node->nid . '.json";');
-  drupal_add_http_header('Content-Length', sprintf('%u', strlen($webform)));
-
-  print($webform);
-
-  exit();
-
-}
-
-
-/**
- * @param $node
- *
- * @return array
- *
- * a page callback to import galaxy webform from a json file.
- */
-function import_tripal_galaxy_workflow($node) {
-  if (count($node->webform['components']) < 1) {
-    drupal_set_message('This is not a valid Galaxy webform. This action only works for Galaxy webform.', 'warning');
-    return '';
-  }
-
-  if (isset($node->webform['components'][1])) {
-    if ($node->webform['components'][1]['form_key'] != 'galaxy_webform') {
-      drupal_set_message('This is not a valid Galaxy webform. This action only works for Galaxy webform.', 'warning');
-      return '';
-    };
-  }
-
-  // store nid and workflow id.
-  $workflow_and_node_ids = [
-    'nid' => $node->nid,
-    'workflow_id' => $node->webform['components'][1]['extra']['workflow_id'],
-  ];
-  $build_page = [
-    'json_markup' => [
-      '#markup' => t('<h1>Replace Galaxy Webform</h1>' .
-        '<p>Import a well-annotated Galaxy webform in JSON format
-        to replace this original Galaxy webform.</p>'),
-    ],
-    'form' => drupal_get_form('galaxy_webform_import_form', $workflow_and_node_ids),
-  ];
-
-  return $build_page;
-}
 
 /**
  * Implements hook_node_access().


### PR DESCRIPTION
The export/import workflow functionality was for sharing annotated workflows across Tripal site. The PR #77 enables getting annotation directly from Galaxy. We no longer need this functionality. 