### PR TITLE
Display help message from tool inputs

### DIFF
--- a/includes/tripal_galaxy.webform.inc
+++ b/includes/tripal_galaxy.webform.inc
@@ -54,6 +54,10 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
   $steps = $workflow['steps'];
   foreach ($steps as $step_index => $step) {
 
+    $step_annotation = '';
+    if (isset($step['annotation'])) {
+      $step_annotation = $step['annotation'];
+    }
     // Each step is contained in a fieldset. We'll name the field set after
     // it's step and if a tool is present we'll include the tool info.
     $cid = count($webform->components) + 1;
@@ -69,7 +73,7 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
       'type' => 'fieldset',
       'value' => '',
       'extra' => [
-        'description' => '',
+        'description' => $step_annotation,
         'description_above' => 1,
         'private' => 0,
         'css_classes' => 'tripal-galaxy-fieldset',
@@ -166,7 +170,7 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
         // We want to change the name of the fieldset to have the name of
         // the tool.
         // we also want to add tool description to the end, like what we see in Galaxy.
-        $fieldset_name .= ': ' . $tool['name'] . ' ' . $tool['description'] . ' (Galaxy Version ' . $tool['version'] . ')';
+        $fieldset_name .= ': ' . $tool['name'] . ' (Galaxy Version ' . $tool['version'] . ')';
         $webform->components[$fieldset_cid - 1]['name'] = $fieldset_name;
 
 

--- a/includes/tripal_galaxy.webform.inc
+++ b/includes/tripal_galaxy.webform.inc
@@ -410,7 +410,6 @@ function tripal_galaxy_build_webform_add_tool_input($webform, $workflow, $step,
     $tool, $tool_input, $pid = 0, $data_inputs) {
 
   $step_index = $step['id'];
-
   // We want to keep track of which inputs come from a repeat input type
   // because there can be multiple values at different indicies.
   $is_repeat = array_key_exists('is_repeat', $tool_input) ? $tool_input['is_repeat'] : FALSE;
@@ -566,9 +565,13 @@ function tripal_galaxy_build_webform_add_component($webform, $workflow, $step,
   $webform_value = "";
   $webform_type = 'select';
   $is_required = 1;
+  $extra_description = '';
+  if (isset($input['help'])) {
+    $extra_description = $input['help'];
+  }
   $extra = [
     'title_display' => 'before',
-    'description' => '',
+    'description' => $extra_description,
     'description_above' => 0,
     'items' => '',
     'aslist' => $is_list,

--- a/theme/css/tripal_galaxy.css
+++ b/theme/css/tripal_galaxy.css
@@ -23,3 +23,7 @@
   white-space: nowrap;
   overflow: hidden;
 }
+
+.tripal-galaxy-fieldset .fieldset-description {
+  color: #0099ff;
+}


### PR DESCRIPTION
Currently, the help message for each tool input is missing from the workflow. This PR helps extract that information and display it in the workflow. Below is an example of when the help messages are displayed.

<img width="711" alt="screen shot 2018-03-29 at 2 18 00 pm" src="https://user-images.githubusercontent.com/1262709/38106236-5bf68086-335c-11e8-9009-d841ef687836.png">

This PR also fixes missing description issues like #54 