### PR TITLE
Empty optional settings fieldset

### DIFF
--- a/includes/tripal_galaxy.webform.inc
+++ b/includes/tripal_galaxy.webform.inc
@@ -173,28 +173,36 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
         $fieldset_name .= ': ' . $tool['name'] . ' (Galaxy Version ' . $tool['version'] . ')';
         $webform->components[$fieldset_cid - 1]['name'] = $fieldset_name;
 
-
-        // Add the "Optional settings" fieldset.
-        $dcid = count($webform->components) + 1;
-        $webform->components[] = [
-          'cid' => $dcid,
-          'pid' => $cid,
-          'form_key' => $fieldset_key . '_additional',
-          'name' => 'Optional Settings',
-          'type' => 'fieldset',
-          'value' => '',
-          'extra' => [
-            'description_above' => 1,
-            'private' => 0,
-            'css_classes' => '',
-            'title_display' => 1,
-            'collapsible' => 1,
-            'collapsed' => 1,
-          ],
-          'required' => '0',
-          'weight' => '1000',
-        ];
-        $webform->current_optional_fieldset = $dcid;
+        // only add optional settings fieldset when the tool has non-data and non-conditional input types.
+        $add_optional_settings_fieldset = FALSE;
+        foreach ($tool['inputs'] as $input) {
+          if ($input['type'] != 'data' & $input['type'] != 'conditional') {
+            $add_optional_settings_fieldset = TRUE;
+          }
+        }
+        if ($add_optional_settings_fieldset) {
+          // Add the "Optional settings" fieldset.
+          $dcid = count($webform->components) + 1;
+          $webform->components[] = [
+            'cid' => $dcid,
+            'pid' => $cid,
+            'form_key' => $fieldset_key . '_additional',
+            'name' => 'Optional Settings',
+            'type' => 'fieldset',
+            'value' => '',
+            'extra' => [
+              'description_above' => 1,
+              'private' => 0,
+              'css_classes' => '',
+              'title_display' => 1,
+              'collapsible' => 1,
+              'collapsed' => 1,
+            ],
+            'required' => '0',
+            'weight' => '1000',
+          ];
+          $webform->current_optional_fieldset = $dcid;
+        }
 
         // Itearte through each of the inputs of this tool and add them
         // to the webform.

--- a/includes/tripal_galaxy.webform.inc
+++ b/includes/tripal_galaxy.webform.inc
@@ -54,6 +54,10 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
   $steps = $workflow['steps'];
   foreach ($steps as $step_index => $step) {
 
+    $step_annotation = '';
+    if (isset($step['annotation'])) {
+      $step_annotation = $step['annotation'];
+    }
     // Each step is contained in a fieldset. We'll name the field set after
     // it's step and if a tool is present we'll include the tool info.
     $cid = count($webform->components) + 1;
@@ -69,7 +73,7 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
       'type' => 'fieldset',
       'value' => '',
       'extra' => [
-        'description' => '',
+        'description' => $step_annotation,
         'description_above' => 1,
         'private' => 0,
         'css_classes' => 'tripal-galaxy-fieldset',
@@ -166,7 +170,7 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
         // We want to change the name of the fieldset to have the name of
         // the tool.
         // we also want to add tool description to the end, like what we see in Galaxy.
-        $fieldset_name .= ': ' . $tool['name'] . ' ' . $tool['description'] . ' (Galaxy Version ' . $tool['version'] . ')';
+        $fieldset_name .= ': ' . $tool['name'] . ' (Galaxy Version ' . $tool['version'] . ')';
         $webform->components[$fieldset_cid - 1]['name'] = $fieldset_name;
 
 

--- a/includes/tripal_galaxy.webform.inc
+++ b/includes/tripal_galaxy.webform.inc
@@ -173,36 +173,27 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
         $fieldset_name .= ': ' . $tool['name'] . ' (Galaxy Version ' . $tool['version'] . ')';
         $webform->components[$fieldset_cid - 1]['name'] = $fieldset_name;
 
-        // only add optional settings fieldset when the tool has non-data and non-conditional input types.
-        $add_optional_settings_fieldset = FALSE;
-        foreach ($tool['inputs'] as $input) {
-          if ($input['type'] != 'data' & $input['type'] != 'conditional') {
-            $add_optional_settings_fieldset = TRUE;
-          }
-        }
-        if ($add_optional_settings_fieldset) {
-          // Add the "Optional settings" fieldset.
-          $dcid = count($webform->components) + 1;
-          $webform->components[] = [
-            'cid' => $dcid,
-            'pid' => $cid,
-            'form_key' => $fieldset_key . '_additional',
-            'name' => 'Optional Settings',
-            'type' => 'fieldset',
-            'value' => '',
-            'extra' => [
-              'description_above' => 1,
-              'private' => 0,
-              'css_classes' => '',
-              'title_display' => 1,
-              'collapsible' => 1,
-              'collapsed' => 1,
-            ],
-            'required' => '0',
-            'weight' => '1000',
-          ];
-          $webform->current_optional_fieldset = $dcid;
-        }
+        // Add the "Optional settings" fieldset.
+        $dcid = count($webform->components) + 1;
+        $webform->components[] = [
+          'cid' => $dcid,
+          'pid' => $cid,
+          'form_key' => $fieldset_key . '_additional',
+          'name' => 'Optional Settings',
+          'type' => 'fieldset',
+          'value' => '',
+          'extra' => [
+            'description_above' => 1,
+            'private' => 0,
+            'css_classes' => '',
+            'title_display' => 1,
+            'collapsible' => 1,
+            'collapsed' => 1,
+          ],
+          'required' => '0',
+          'weight' => '1000',
+        ];
+        $webform->current_optional_fieldset = $dcid;
 
         // Itearte through each of the inputs of this tool and add them
         // to the webform.
@@ -263,6 +254,27 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
   $node->uid = 1;
   $node->promote = 0;
   $node->comment = 0;
+
+
+  // if an Optional Settings component has no child component, it should be removed.
+  $optional_settings_cids = [];
+  $other_component_pids = [];
+  foreach ($webform->components as $component_key=>$component_value) {
+    // if this is an Optional Settings component, we save the cid;
+    // else, we save the pid.
+    if ($component_value['type'] == 'fieldset' and $component_value['name'] == 'Optional Settings') {
+      $optional_settings_cids[$component_key] = $component_value['cid'];
+    }
+    else {
+      $other_component_pids[$component_key] = $component_value['pid'];
+    }
+  }
+  // any element in $optional_settings_cids that are not in $other_component_pids indicates
+  // an empty Optional Settings component. This component should be removed.
+  $empty_optional_settings_components = array_diff($optional_settings_cids, $other_component_pids);
+  foreach (array_keys($empty_optional_settings_components) as $component_key) {
+    unset($webform->components[$component_key]);
+  }
 
   // Attach the webform to the node.
   $node->webform = [

--- a/includes/tripal_galaxy.webform.inc
+++ b/includes/tripal_galaxy.webform.inc
@@ -821,11 +821,14 @@ function tripal_galaxy_build_webform_add_component($webform, $workflow, $step,
   }
 
   // If this component has a value then put it in the "Optional Settings"
-  if (!$is_required or $webform_value or $webform_value === 0) {
-    if (!$linked) {
-      $pid = $webform->current_optional_fieldset;
-    }
-  }
+//  if ($input['type'] != 'data' and $input['type'] != 'conditional') {
+//    if (!$is_required or $webform_value or $webform_value === 0) {
+//      if (!$linked) {
+//        $pid = $webform->current_optional_fieldset;
+//      }
+//    }
+//  }
+
 
   $cid = count($webform->components) + 1;
   $component = [
@@ -841,6 +844,10 @@ function tripal_galaxy_build_webform_add_component($webform, $workflow, $step,
     'weight' => $cid,
     'required' => $is_required,
   ];
+  if ($component['type'] != 'fixed_value' and isset($webform->current_optional_fieldset)) {
+    $component['pid'] = $webform->current_optional_fieldset;
+  }
+
   $webform->components[] = $component;
 
   return $cid;

--- a/includes/tripal_galaxy.webform.inc
+++ b/includes/tripal_galaxy.webform.inc
@@ -410,7 +410,6 @@ function tripal_galaxy_build_webform_add_tool_input($webform, $workflow, $step,
     $tool, $tool_input, $pid = 0, $data_inputs) {
 
   $step_index = $step['id'];
-
   // We want to keep track of which inputs come from a repeat input type
   // because there can be multiple values at different indicies.
   $is_repeat = array_key_exists('is_repeat', $tool_input) ? $tool_input['is_repeat'] : FALSE;
@@ -566,9 +565,13 @@ function tripal_galaxy_build_webform_add_component($webform, $workflow, $step,
   $webform_value = "";
   $webform_type = 'select';
   $is_required = 1;
+  $extra_description = '';
+  if (isset($input['help'])) {
+    $extra_description = $input['help'];
+  }
   $extra = [
     'title_display' => 'before',
-    'description' => '',
+    'description' => $extra_description,
     'description_above' => 0,
     'items' => '',
     'aslist' => $is_list,

--- a/theme/css/tripal_galaxy.css
+++ b/theme/css/tripal_galaxy.css
@@ -23,3 +23,7 @@
   white-space: nowrap;
   overflow: hidden;
 }
+
+.tripal-galaxy-fieldset .fieldset-description {
+  color: #0099ff;
+}


### PR DESCRIPTION
In some situations, an **Optional Settings** fieldset does not have child field. The **Optional Settings** fieldset in these situations should be removed from the workflow. This is an improved solution of #80 

See the two screenshots:
<img width="717" alt="screen shot 2018-03-30 at 10 47 29 am" src="https://user-images.githubusercontent.com/1262709/38141822-f91f78e4-3407-11e8-8000-d5929a778954.png">


<img width="707" alt="screen shot 2018-03-30 at 10 47 45 am" src="https://user-images.githubusercontent.com/1262709/38141817-f328d76e-3407-11e8-8550-0da21e646d69.png">
