### PR TITLE
Display error message when no workflows in galaxy

### DIFF
--- a/includes/tripal_galaxy.admin_workflow_form_add.inc
+++ b/includes/tripal_galaxy.admin_workflow_form_add.inc
@@ -66,6 +66,10 @@ function tripal_galaxy_admin_add_workflow_form($form, &$form_state) {
     $workflows = $gworkflows->index();
     if (!$workflows) {
       $error = $galaxy->getError();
+      if (empty($error['message'])) {
+        $error['message'] = 'No workflow is found in this Galaxy server for the user you used
+        to connect to the Galaxy server.';
+      }
       drupal_set_message($error['message'], 'error');
       return $form;
     }

--- a/includes/tripal_galaxy.webform.inc
+++ b/includes/tripal_galaxy.webform.inc
@@ -173,36 +173,28 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
         $fieldset_name .= ': ' . $tool['name'] . ' (Galaxy Version ' . $tool['version'] . ')';
         $webform->components[$fieldset_cid - 1]['name'] = $fieldset_name;
 
-        // only add optional settings fieldset when the tool has non-data and non-conditional input types.
-        $add_optional_settings_fieldset = FALSE;
-        foreach ($tool['inputs'] as $input) {
-          if ($input['type'] != 'data' & $input['type'] != 'conditional') {
-            $add_optional_settings_fieldset = TRUE;
-          }
-        }
-        if ($add_optional_settings_fieldset) {
-          // Add the "Optional settings" fieldset.
-          $dcid = count($webform->components) + 1;
-          $webform->components[] = [
-            'cid' => $dcid,
-            'pid' => $cid,
-            'form_key' => $fieldset_key . '_additional',
-            'name' => 'Optional Settings',
-            'type' => 'fieldset',
-            'value' => '',
-            'extra' => [
-              'description_above' => 1,
-              'private' => 0,
-              'css_classes' => '',
-              'title_display' => 1,
-              'collapsible' => 1,
-              'collapsed' => 1,
-            ],
-            'required' => '0',
-            'weight' => '1000',
-          ];
-          $webform->current_optional_fieldset = $dcid;
-        }
+
+        // Add the "Optional settings" fieldset.
+        $dcid = count($webform->components) + 1;
+        $webform->components[] = [
+          'cid' => $dcid,
+          'pid' => $cid,
+          'form_key' => $fieldset_key . '_additional',
+          'name' => 'Optional Settings',
+          'type' => 'fieldset',
+          'value' => '',
+          'extra' => [
+            'description_above' => 1,
+            'private' => 0,
+            'css_classes' => '',
+            'title_display' => 1,
+            'collapsible' => 1,
+            'collapsed' => 1,
+          ],
+          'required' => '0',
+          'weight' => '1000',
+        ];
+        $webform->current_optional_fieldset = $dcid;
 
         // Itearte through each of the inputs of this tool and add them
         // to the webform.


### PR DESCRIPTION
This fix displays an error message when trying to add workflows but no workflows exist in the Galaxy server.