### PR TITLE
7.x 1.x 66 unavailable server

### DIFF
--- a/api/tripal_galaxy.api.inc
+++ b/api/tripal_galaxy.api.inc
@@ -886,4 +886,3 @@ function tripal_galaxy_get_files_dir() {
 
   return $site_dir;
 }
-

--- a/includes/tripal_galaxy.admin.inc
+++ b/includes/tripal_galaxy.admin.inc
@@ -23,11 +23,32 @@ function tripal_galaxy_admin_home() {
   $results = db_query($sql);
 
   while ($result = $results->fetchObject()) {
+    //Check the status of the server to determine which link to include.
+    if ($results->serverstatus == 'unavailable') {
+      $status_link = l('disable all workflows', '/admin/tripal/extension/galaxy/disable/' . $result->galaxy_id);
+    }
+    elseif ($results->serverstatus == 'available') {
+      //Now check if any workflows are disable
+      $workflow = db_select('tripal_galaxy_workflow', 'tgw')
+        ->fields('tgw')
+        ->condition('galaxy_id', $$result->galaxy_id)
+        ->execute()
+        ->fetchObject();
+
+        if ($workflow) {
+          $status_link = l('enable all workflows', '/admin/tripal/extension/galaxy/enable/' . $result->galaxy_id);
+        }
+        else {
+          $status_link = NULL;
+        }
+
+    }
     $rows[] = array(
       $result->servername,
       $result->description,
       l('edit', '/admin/tripal/extension/galaxy/edit/' . $result->galaxy_id) . ' ' .
-      l('test', '/admin/tripal/extension/galaxy/test/' . $result->galaxy_id)
+      l('test', '/admin/tripal/extension/galaxy/test/' . $result->galaxy_id) . ' ' . 
+      $status_link
     );
   }
 
@@ -185,4 +206,61 @@ function tripal_galaxy_admin_confirm_remove_workflow_form($form, &$form_state, $
 function tripal_galaxy_admin_test_server($galaxy_id) {
   tripal_galaxy_test_connection(array('galaxy_id' => $galaxy_id));
   drupal_goto('admin/tripal/extension/galaxy');
+}
+
+/**
+ * Responds to the menu item admin/tripal/extension/galaxy/disable/%.
+ *
+ * @param  $galaxy_id
+ *   A galaxy server ID
+ */
+function tripal_galaxy_admin_disable_workflows($galaxy_id) {
+
+  try {
+    $sql = "SELECT * FROM {tripal_galaxy_workflow} WHERE galaxy_id = $galaxy_id";
+    $results = db_query($sql);
+
+    while ($result = $results->fetchObject()) {
+      $sucess = db_update('tripal_galaxy_workflow')
+        ->fields(array(
+          'status' => 'disable',
+        ))
+        ->condition('galaxy_id', $galaxy_id, '=')
+        ->execute();
+    }
+  } catch (Exception $e) {
+    $transaction->rollback();
+    drupal_set_message($e->getMessage(), 'error');
+    drupal_set_message(t('Cannot disable the workflows'), 'error');
+    drupal_goto("/admin/tripal/extension/galaxy/workflows");
+    return;
+  }
+}
+
+/**
+ * Responds to the menu item admin/tripal/extension/enable/test/%.
+ *
+ * @param  $galaxy_id
+ *   A galaxy server ID
+ */
+function tripal_galaxy_admin_enable_workflows($galaxy_id) {
+  try {
+    $sql = "SELECT * FROM {tripal_galaxy_workflow} WHERE galaxy_id = $galaxy_id";
+    $results = db_query($sql);
+
+    while ($result = $results->fetchObject()) {
+      $sucess = db_update('tripal_galaxy_workflow')
+        ->fields(array(
+          'status' => 'Active',
+        ))
+        ->condition('galaxy_id', $galaxy_id, '=')
+        ->execute();
+    }
+  } catch (Exception $e) {
+    $transaction->rollback();
+    drupal_set_message($e->getMessage(), 'error');
+    drupal_set_message(t('Cannot disable the workflows'), 'error');
+    drupal_goto("/admin/tripal/extension/galaxy/workflows");
+    return;
+  }
 }

--- a/includes/tripal_galaxy.admin.inc
+++ b/includes/tripal_galaxy.admin.inc
@@ -23,20 +23,36 @@ function tripal_galaxy_admin_home() {
   $results = db_query($sql);
 
   while ($result = $results->fetchObject()) {
-    //Check the status of the server to determine which link to include.
-    if ($results->serverstatus == 'unavailable') {
-      $status_link = l('disable all workflows', '/admin/tripal/extension/galaxy/disable/' . $result->galaxy_id);
-    }
-    elseif ($results->serverstatus == 'available') {
-      //Now check if any workflows are disable
-      $workflow = db_select('tripal_galaxy_workflow', 'tgw')
-        ->fields('tgw')
-        ->condition('galaxy_id', $$result->galaxy_id)
-        ->execute()
-        ->fetchObject();
 
-        if ($workflow) {
-          $status_link = l('enable all workflows', '/admin/tripal/extension/galaxy/enable/' . $result->galaxy_id);
+    $disabled_workflows = db_select('tripal_galaxy_workflow', 'tgw')
+      ->fields('tgw')
+      ->condition('galaxy_id', $result->galaxy_id)
+      ->condition('status', 'disabled')
+      ->execute()
+      ->fetchObject();
+
+    $enabled_workflows = db_select('tripal_galaxy_workflow', 'tgw')
+      ->fields('tgw')
+      ->condition('galaxy_id', $result->galaxy_id)
+      ->condition('status', 'Active')
+      ->execute()
+      ->fetchObject();
+
+    //Check the status of the server to determine which link to include.
+    if ($result->serverstatus == 'unavailable') {
+      if ($disabled_workflows && $enabled_workflows == NULL) {
+        $status_link = t("<br /> All workflows for this server are disabled.");
+        $status_link .= t("<br /> <b> The galaxy server is still unavailable, 
+                           <br /> enabling your workflows is not recommended.</b> <br />");
+        $status_link .= l("\n enable all workflows", '/admin/tripal/extension/galaxy/enable/' . $result->galaxy_id);
+      }
+      else {
+        $status_link = l("\t disable all workflows", '/admin/tripal/extension/galaxy/disable/' . $result->galaxy_id);
+      }
+    }
+    elseif ($result->serverstatus == 'available') {
+        if ($disabled_workflows) {
+          $status_link = l("\t enable all workflows", '/admin/tripal/extension/galaxy/enable/' . $result->galaxy_id);
         }
         else {
           $status_link = NULL;
@@ -223,16 +239,19 @@ function tripal_galaxy_admin_disable_workflows($galaxy_id) {
     while ($result = $results->fetchObject()) {
       $sucess = db_update('tripal_galaxy_workflow')
         ->fields(array(
-          'status' => 'disable',
+          'status' => 'disabled',
         ))
         ->condition('galaxy_id', $galaxy_id, '=')
         ->execute();
     }
+    drupal_set_message(t('All workflows disabled'), 'status');
+    drupal_goto("/admin/tripal/extension/galaxy");
+
   } catch (Exception $e) {
     $transaction->rollback();
     drupal_set_message($e->getMessage(), 'error');
     drupal_set_message(t('Cannot disable the workflows'), 'error');
-    drupal_goto("/admin/tripal/extension/galaxy/workflows");
+    drupal_goto("/admin/tripal/extension/galaxy");
     return;
   }
 }
@@ -256,11 +275,14 @@ function tripal_galaxy_admin_enable_workflows($galaxy_id) {
         ->condition('galaxy_id', $galaxy_id, '=')
         ->execute();
     }
+    drupal_set_message(t('All workflows enabled'), 'status');
+    drupal_goto("/admin/tripal/extension/galaxy");
+
   } catch (Exception $e) {
     $transaction->rollback();
     drupal_set_message($e->getMessage(), 'error');
     drupal_set_message(t('Cannot disable the workflows'), 'error');
-    drupal_goto("/admin/tripal/extension/galaxy/workflows");
+    drupal_goto("/admin/tripal/extension/galaxy");
     return;
   }
 }

--- a/includes/tripal_galaxy.admin.inc
+++ b/includes/tripal_galaxy.admin.inc
@@ -39,6 +39,7 @@ function tripal_galaxy_admin_home() {
       ->fetchObject();
 
     //Check the status of the server to determine which link to include.
+    $status_link = '';
     if ($result->serverstatus == 'unavailable') {
       if ($disabled_workflows && $enabled_workflows == NULL) {
         $status_link = t("<br /> All workflows for this server are disabled.");
@@ -55,15 +56,15 @@ function tripal_galaxy_admin_home() {
           $status_link = l("\t enable all workflows", '/admin/tripal/extension/galaxy/enable/' . $result->galaxy_id);
         }
         else {
-          $status_link = NULL;
+          $status_link = l("\t disable all workflows", '/admin/tripal/extension/galaxy/disable/' . $result->galaxy_id);
         }
 
     }
     $rows[] = array(
       $result->servername,
       $result->description,
-      l('edit', '/admin/tripal/extension/galaxy/edit/' . $result->galaxy_id) . ' ' .
-      l('test', '/admin/tripal/extension/galaxy/test/' . $result->galaxy_id) . ' ' . 
+      l('edit', '/admin/tripal/extension/galaxy/edit/' . $result->galaxy_id) . ' | ' .
+      l('test', '/admin/tripal/extension/galaxy/test/' . $result->galaxy_id) . ' | ' . 
       $status_link
     );
   }
@@ -220,7 +221,25 @@ function tripal_galaxy_admin_confirm_remove_workflow_form($form, &$form_state, $
  *   A galaxy server ID
  */
 function tripal_galaxy_admin_test_server($galaxy_id) {
-  tripal_galaxy_test_connection(array('galaxy_id' => $galaxy_id));
+  $status = tripal_galaxy_test_connection(array('galaxy_id' => $galaxy_id));
+  if ($status === FALSE) {
+    // Update status in the db.
+    db_update('tripal_galaxy')
+      ->fields(array(
+        'serverstatus' => 'unavailable',
+      ))
+      ->condition('galaxy_id', $result->galaxy_id, '=')
+      ->execute();
+  }
+  else if ($status === TRUE) {
+    // Update status in the db.
+    db_update('tripal_galaxy')
+      ->fields(array(
+        'serverstatus' => 'available',
+      ))
+      ->condition('galaxy_id', $result->galaxy_id, '=')
+      ->execute();
+  }
   drupal_goto('admin/tripal/extension/galaxy');
 }
 
@@ -257,6 +276,35 @@ function tripal_galaxy_admin_disable_workflows($galaxy_id) {
 }
 
 /**
+ * Responds to the menu item admin/tripal/extension/galaxy/disable/%.
+ *
+ * @param  $galaxy_id
+ *   A galaxy server ID
+ */
+function tripal_galaxy_admin_disable_workflow($galaxy_workflow_id)
+{
+
+  try {
+    db_update('tripal_galaxy_workflow')
+      ->fields(array(
+        'status' => 'disabled',
+      ))
+      ->condition('galaxy_workflow_id', $galaxy_workflow_id, '=')
+      ->execute();
+    
+    drupal_set_message(t('Workflow disabled'), 'status');
+    drupal_goto("/admin/tripal/extension/galaxy/workflows");
+
+  } catch (Exception $e) {
+    $transaction->rollback();
+    drupal_set_message($e->getMessage(), 'error');
+    drupal_set_message(t('Cannot disable the workflow'), 'error');
+    drupal_goto("/admin/tripal/extension/galaxy/workflows");
+    return;
+  }
+}
+
+/**
  * Responds to the menu item admin/tripal/extension/enable/test/%.
  *
  * @param  $galaxy_id
@@ -283,6 +331,34 @@ function tripal_galaxy_admin_enable_workflows($galaxy_id) {
     drupal_set_message($e->getMessage(), 'error');
     drupal_set_message(t('Cannot disable the workflows'), 'error');
     drupal_goto("/admin/tripal/extension/galaxy");
+    return;
+  }
+}
+
+/**
+ * Responds to the menu item admin/tripal/extension/enable/test/%.
+ *
+ * @param  $galaxy_id
+ *   A galaxy server ID
+ */
+function tripal_galaxy_admin_enable_workflow($galaxy_workflow_id)
+{
+  try {
+    $sucess = db_update('tripal_galaxy_workflow')
+      ->fields(array(
+        'status' => 'Active',
+      ))
+      ->condition('galaxy_workflow_id', $galaxy_workflow_id, '=')
+      ->execute();
+    
+    drupal_set_message(t('Workflow enabled'), 'status');
+    drupal_goto("/admin/tripal/extension/galaxy/workflows");
+
+  } catch (Exception $e) {
+    $transaction->rollback();
+    drupal_set_message($e->getMessage(), 'error');
+    drupal_set_message(t('Cannot enable the workflow'), 'error');
+    drupal_goto("/admin/tripal/extension/galaxy/workflows");
     return;
   }
 }

--- a/includes/tripal_galaxy.admin.inc
+++ b/includes/tripal_galaxy.admin.inc
@@ -15,7 +15,7 @@ function tripal_galaxy_admin_home() {
 
   // Initialize the headers and rows of the table.
   $rows = array();
-  $headers = array('Galaxy Server', 'Description', 'Options');
+  $headers = array('Galaxy Server', 'Description', 'Status', 'Options');
 
   // Retrieve the list of galaxy servers that have been added and generate
   // the rows for the table.
@@ -42,13 +42,10 @@ function tripal_galaxy_admin_home() {
     $status_link = '';
     if ($result->serverstatus == 'unavailable') {
       if ($disabled_workflows && $enabled_workflows == NULL) {
-        $status_link = t("<br /> All workflows for this server are disabled.");
-        $status_link .= t("<br /> <b> The galaxy server is still unavailable, 
-                           <br /> enabling your workflows is not recommended.</b> <br />");
-        $status_link .= l("\n enable all workflows", '/admin/tripal/extension/galaxy/enable/' . $result->galaxy_id);
+        $status_link = l("enable all workflows", '/admin/tripal/extension/galaxy/enable/' . $result->galaxy_id);
       }
       else {
-        $status_link = l("\t disable all workflows", '/admin/tripal/extension/galaxy/disable/' . $result->galaxy_id);
+        $status_link = l("disable all workflows", '/admin/tripal/extension/galaxy/disable/' . $result->galaxy_id);
       }
     }
     elseif ($result->serverstatus == 'available') {
@@ -63,6 +60,7 @@ function tripal_galaxy_admin_home() {
     $rows[] = array(
       $result->servername,
       $result->description,
+      $result->serverstatus,
       l('edit', '/admin/tripal/extension/galaxy/edit/' . $result->galaxy_id) . ' | ' .
       l('test', '/admin/tripal/extension/galaxy/test/' . $result->galaxy_id) . ' | ' . 
       $status_link
@@ -228,7 +226,7 @@ function tripal_galaxy_admin_test_server($galaxy_id) {
       ->fields(array(
         'serverstatus' => 'unavailable',
       ))
-      ->condition('galaxy_id', $result->galaxy_id, '=')
+      ->condition('galaxy_id', $galaxy_id, '=')
       ->execute();
   }
   else if ($status === TRUE) {
@@ -237,7 +235,7 @@ function tripal_galaxy_admin_test_server($galaxy_id) {
       ->fields(array(
         'serverstatus' => 'available',
       ))
-      ->condition('galaxy_id', $result->galaxy_id, '=')
+      ->condition('galaxy_id', $galaxy_id, '=')
       ->execute();
   }
   drupal_goto('admin/tripal/extension/galaxy');

--- a/includes/tripal_galaxy.admin_workflow_form.inc
+++ b/includes/tripal_galaxy.admin_workflow_form.inc
@@ -52,11 +52,17 @@ function tripal_galaxy_admin_workflows_form($form, &$form_state) {
       '#markup' => 'Workflow ID: ' . $workflow->workflow_id . '</br>' .
         'Workflow UUID: ' . $workflow->workflow_uuid . '',
     );
+    if ($workflow->status == 'Active') {
+      $status_change = l("Disable", '/admin/tripal/extension/galaxy/workflows/disable/' . $workflow->galaxy_workflow_id);
+    } else if ($workflow->status == 'disabled') {
+        $status_change = l("Enable", '/admin/tripal/extension/galaxy/workflows/enable/' . $workflow->galaxy_workflow_id);
+    }
     $form['rows'][$i]['actions-' . $i] = array(
       '#type' => 'item',
-      '#markup' => l('Remove', '/admin/tripal/extension/galaxy/workflows/remove/' . $workflow->galaxy_workflow_id)
+      '#markup' => l('Remove', '/admin/tripal/extension/galaxy/workflows/remove/' . $workflow->galaxy_workflow_id) . '  |  ' .
+      $status_change
     );
-
+   
     $i++;
   }
 

--- a/tripal_galaxy.install
+++ b/tripal_galaxy.install
@@ -312,8 +312,7 @@ function tripal_galaxy_update_7102() {
 }
 
 /**
- * This update previously added support for file quotas, but that code
- * has been moved to the core Tripal. Therefore, this update does nothing now.
+ * This update adds the serverstatus column to the tripal_galaxy table.
  */
 function tripal_galaxy_update_7103()
 {

--- a/tripal_galaxy.install
+++ b/tripal_galaxy.install
@@ -61,8 +61,13 @@ function tripal_galaxy_add_galaxy_table(&$schema) {
       ),
       'description' => array(
         'type' => 'text',
-      'not NULL' => FALSE,
+        'not NULL' => FALSE,
        ),
+      'serverstatus' => array(
+        'type' => 'varchar',
+        'length ' => 1024,
+        'not NULL' => FALSE,
+      ),
     ),
     'primary key' => array(
        0 => 'galaxy_id',
@@ -303,5 +308,24 @@ function tripal_galaxy_update_7102() {
   catch (\PDOException $e) {
     $error = $e->getMessage();
     throw new DrupalUpdateException('Could not update the tripal_galaxy_custom_quota table: '. $error);
+  }
+}
+
+/**
+ * This update previously added support for file quotas, but that code
+ * has been moved to the core Tripal. Therefore, this update does nothing now.
+ */
+function tripal_galaxy_update_7103()
+{
+  try {
+    $status = array(
+      'type' => 'varchar',
+      'length ' => 1024,
+      'not NULL' => FALSE,
+    );
+    db_add_field('tripal_galaxy', 'serverstatus', $status);
+  } catch (\PDOException $e) {
+    $error = $e->getMessage();
+    throw new DrupalUpdateException('Could not update the tripal_galaxy table: ' . $error);
   }
 }

--- a/tripal_galaxy.module
+++ b/tripal_galaxy.module
@@ -463,7 +463,7 @@ function tripal_galaxy_form_webform_client_form_alter(&$form, &$form_state, $for
   if ($workflow and $workflow->status == 'Altered') {
     drupal_set_message('Unfortunately, this wokflow is deprecated and no longer
         avaliable for submissions.', 'error');
-    tripal_set_message('Dear site administrator. This form is disabled because the workflow was
+    tripal_set_message('This form is disabled because the workflow was
         altered on the remote Galaxy Instance and may be out of sync
         with this web form.  If you want to continue to offer this workflow
         to your site visitors, you will need to ' . l('add the workflow', 'admin/tripal/extension/galaxy/workflows') . ' again as a new web form on this site.',
@@ -471,17 +471,10 @@ function tripal_galaxy_form_webform_client_form_alter(&$form, &$form_state, $for
     $form['actions']['next']['#disabled'] = TRUE;
   }
   else if ($workflow and $workflow->status == 'disabled') {
-    drupal_set_message('Unfortunately, this wokflow is disabled because the Galaxy
-                        server it is on is not currently available.', 'error');
-    tripal_set_message(
-      'Dear site administrator. This form is disabled because the remote Galaxy 
-         Instance is unavailable.  If you want to continue to offer this workflow
-        to your site visitors you will need to work with the remote Galaxy instances\'s
-        maintainer to get it back up or move the workflow to another remote Galaxy
-        instance. Once that is done you can enable all workflows
-        here:  ' . l('enable the workflow', 'admin/tripal/extension/galaxy') . '.',
-      TRIPAL_ERROR
-    );
+    drupal_set_message('Unfortunately, this wokflow is disabled and no longer
+        avaliable for submissions.', 'error');
+    tripal_set_message('This form is disabled you may ' . 
+      l('enable the workflow here', 'admin/tripal/extension/galaxy') . '.',TRIPAL_ERROR);
     $form['actions']['next']['#disabled'] = true;
   }
 
@@ -828,7 +821,7 @@ function tripal_galaxy_workflow_report($sid) {
   $history_name = tripal_galaxy_get_history_name($submission, $node);
   $error = [];
   $history = tripal_galaxy_get_history($galaxy_instance, $history_name, $error);
-  dpm($history);
+
   if ($history['deleted'] === TRUE) {
     $content['deleted'] = [
       '#type' => 'item',
@@ -1280,7 +1273,7 @@ function tripal_galaxy_cron() {
   tripal_add_job('Cron: Checking Galaxy workflow status', 'tripal_galaxy',
     'tripal_galaxy_check_status', $args, 1, [], TRUE);
 
-  // Once per day.
+  // TODO: add a setting somewhere to let the user set the date.
   $interval = variable_get('tripal_galaxy_interval', 24 * 60 * 60);
 
   if (time() >= variable_get('tripal_galaxy_next_execution', 0)) {
@@ -1302,13 +1295,15 @@ function tripal_galaxy_cron() {
             ->execute();
 
           // Put a message on the dashboard.
-          $title = 'Galaxy Server ' . $result->servername . ' was unreachable when tested at ' . time();
-          $details = 'Galaxy Server ' . $result->servername . ' was unreachable when tested at ' . time() .
-          'Please check the server status. If the server is down you may disable the workflows associated
-          with that server by going to the Tripal Galaxy admin page.';
-          $actions['disable_workflow'] = 'admin/import/field/' . $details['field_name'] . '/' . $bundle->name . '/' . $module . '/instance';
+          $title = t('Galaxy Server %servername was unreachable when tested at %time', 
+              array('%server' => $result->servername, '%time' => format_date(time())));
+          $details = t('Galaxy Server %servername was unreachable when tested at %time ' .
+           'Please check the server status. If the server is down you may disable the workflows associated ' .
+           'with that server by going to the Tripal Galaxy admin page.', 
+            array('%server' => $result->servername, '%time' => format_date(time())));
+          $actions['Disable Server\'s Workflows'] = 'admin/tripal/extension/galaxy/disable/' . $result->galaxy_id;
           $type = 'Tripal Galaxy';
-          $submitter_id = 'tripal_galaxy' . $result->servername;
+          $submitter_id = 'tripal_galaxy' . $result->servername . time();
           tripal_add_notification($title, $details, $type, $actions, $submitter_id);
           // $result->servername,
           // $result->description,
@@ -1334,14 +1329,14 @@ function tripal_galaxy_cron() {
           }  
         }   
       }
-
-  } catch (Exception $e) {
-    $transaction->rollback();
-    drupal_set_message($e->getMessage(), 'error');
-    drupal_set_message(t('Cannot disable the workflows'), 'error');
-    drupal_goto("/admin/tripal/extension/galaxy/workflows");
-    return;
-  }
+    } 
+    catch (Exception $e) {
+      $transaction->rollback();
+      drupal_set_message($e->getMessage(), 'error');
+      drupal_set_message(t('Cannot disable the workflows'), 'error');
+      drupal_goto("/admin/tripal/extension/galaxy/workflows");
+      return;
+    }
     variable_set('tripal_galaxy_next_execution', time() + $interval);
   }
 }

--- a/tripal_galaxy.module
+++ b/tripal_galaxy.module
@@ -127,7 +127,7 @@ function tripal_galaxy_menu() {
 
   // Enable workflows for this Galaxy
   $items['admin/tripal/extension/galaxy/enable/%'] = [
-    'description' => 'Disable all workflows for this galaxy server',
+    'description' => 'Enable all workflows for this galaxy server',
     'page callback' => 'tripal_galaxy_admin_enable_workflows',
     'page arguments' => [5],
     'access arguments' => ['administer galaxy'],
@@ -194,6 +194,31 @@ function tripal_galaxy_menu() {
     'file path' => drupal_get_path('module', 'tripal_galaxy'),
     'weight' => 10,
   ];
+
+    // Disable Workflows
+  $items['admin/tripal/extension/galaxy/workflows/disable/%'] = [
+    'description' => 'Disable this workflow',
+    'page callback' => 'tripal_galaxy_admin_disable_workflow',
+    'page arguments' => [6],
+    'access arguments' => ['administer galaxy'],
+    'type' => MENU_CALLBACK,
+    'file' => 'includes/tripal_galaxy.admin.inc',
+    'file path' => drupal_get_path('module', 'tripal_galaxy'),
+    'weight' => 10,
+  ];
+
+    // Enable Workflows
+  $items['admin/tripal/extension/galaxy/workflows/enable/%'] = [
+    'description' => 'Enable this workflow',
+    'page callback' => 'tripal_galaxy_admin_enable_workflow',
+    'page arguments' => [6],
+    'access arguments' => ['administer galaxy'],
+    'type' => MENU_CALLBACK,
+    'file' => 'includes/tripal_galaxy.admin.inc',
+    'file path' => drupal_get_path('module', 'tripal_galaxy'),
+    'weight' => 10,
+  ];
+
 
   // Admin submission report.
   $items['admin/tripal/extension/galaxy/workflows/report/%'] = [
@@ -445,6 +470,21 @@ function tripal_galaxy_form_webform_client_form_alter(&$form, &$form_state, $for
       TRIPAL_ERROR);
     $form['actions']['next']['#disabled'] = TRUE;
   }
+  else if ($workflow and $workflow->status == 'disabled') {
+    drupal_set_message('Unfortunately, this wokflow is disabled because the Galaxy
+                        server it is on is not currently available.', 'error');
+    tripal_set_message(
+      'Dear site administrator. This form is disabled because the remote Galaxy 
+         Instance is unavailable.  If you want to continue to offer this workflow
+        to your site visitors you will need to work with the remote Galaxy instances\'s
+        maintainer to get it back up or move the workflow to another remote Galaxy
+        instance. Once that is done you can enable all workflows
+        here:  ' . l('enable the workflow', 'admin/tripal/extension/galaxy') . '.',
+      TRIPAL_ERROR
+    );
+    $form['actions']['next']['#disabled'] = true;
+  }
+
 
   // Check if this particular webform really is a galaxy webform
   // At each 'turn of the page' of the particular webform this is being called

--- a/tripal_galaxy.module
+++ b/tripal_galaxy.module
@@ -114,6 +114,28 @@ function tripal_galaxy_menu() {
     'file path' => drupal_get_path('module', 'tripal_galaxy'),
   ];
 
+  // Disable workflows for this Galaxy
+  $items['admin/tripal/extension/galaxy/disable/%'] = [
+    'description' => 'Disable all workflows for this galaxy server',
+    'page callback' => 'tripal_galaxy_admin_disable_workflows',
+    'page arguments' => [5],
+    'access arguments' => ['administer galaxy'],
+    'type' => MENU_CALLBACK,
+    'file' => 'includes/tripal_galaxy.admin.inc',
+    'file path' => drupal_get_path('module', 'tripal_galaxy'),
+  ];
+
+  // Enable workflows for this Galaxy
+  $items['admin/tripal/extension/galaxy/enable/%'] = [
+    'description' => 'Disable all workflows for this galaxy server',
+    'page callback' => 'tripal_galaxy_admin_enable_workflows',
+    'page arguments' => [5],
+    'access arguments' => ['administer galaxy'],
+    'type' => MENU_CALLBACK,
+    'file' => 'includes/tripal_galaxy.admin.inc',
+    'file path' => drupal_get_path('module', 'tripal_galaxy'),
+  ];
+
   // Add Galaxy
   $items['admin/tripal/extension/galaxy/add'] = [
     'description' => 'Add a galaxy server instance',
@@ -1217,6 +1239,71 @@ function tripal_galaxy_cron() {
   $args = [];
   tripal_add_job('Cron: Checking Galaxy workflow status', 'tripal_galaxy',
     'tripal_galaxy_check_status', $args, 1, [], TRUE);
+
+  // Once per day.
+  $interval = variable_get('tripal_galaxy_interval', 24 * 60 * 60);
+
+  if (time() >= variable_get('tripal_galaxy_next_execution', 0)) {
+    try {
+      // Retrieve the list of galaxy servers that have been added and generate
+      // the rows for the table.
+      $sql = "SELECT * FROM {tripal_galaxy}";
+      $results = db_query($sql);
+
+      while ($result = $results->fetchObject()) {
+        $server_status = tripal_galaxy_test_connection(array('galaxy_id' => $result->galaxy_id));
+        if ($server_status === FALSE) {
+          // Update status in the db.
+          db_update('tripal_galaxy')
+            ->fields(array(
+              'serverstatus' => 'unavailable',
+            ))
+            ->condition('galaxy_id', $result->galaxy_id, '=')
+            ->execute();
+
+          // Put a message on the dashboard.
+          $title = 'Galaxy Server ' . $result->servername . ' was unreachable when tested at ' . time();
+          $details = 'Galaxy Server ' . $result->servername . ' was unreachable when tested at ' . time() .
+          'Please check the server status. If the server is down you may disable the workflows associated
+          with that server by going to the Tripal Galaxy admin page.';
+          $actions['disable_workflow'] = 'admin/import/field/' . $details['field_name'] . '/' . $bundle->name . '/' . $module . '/instance';
+          $type = 'Tripal Galaxy';
+          $submitter_id = 'tripal_galaxy' . $result->servername;
+          tripal_add_notification($title, $details, $type, $actions, $submitter_id);
+          // $result->servername,
+          // $result->description,
+        } 
+        else if ($server_status === TRUE) {
+          db_update('tripal_galaxy')
+            ->fields(array(
+              'serverstatus' => 'available',
+            ))
+            ->condition('galaxy_id', $result->galaxy_id, '=')
+            ->execute();
+
+          //Make sure no notification is up about the server being down.
+          $submitter_id = 'tripal_galaxy' . $result->servername;
+          $note = db_select('tripal_admin_notfications', 'tan')
+            ->fields('tan')
+            ->condition('submitter_id', $submitter_id, '=')
+            ->execute()->fetchAll();
+          if ($note) {
+            db_delete('tripal_admin_notfications')
+              ->condition('submitter_id', $submitter_id)
+              ->execute();
+          }  
+        }   
+      }
+
+  } catch (Exception $e) {
+    $transaction->rollback();
+    drupal_set_message($e->getMessage(), 'error');
+    drupal_set_message(t('Cannot disable the workflows'), 'error');
+    drupal_goto("/admin/tripal/extension/galaxy/workflows");
+    return;
+  }
+    variable_set('tripal_galaxy_next_execution', time() + $interval);
+  }
 }
 
 /**


### PR DESCRIPTION
This requires an update.php to be run to add the new serverstatus column to the tripal_galaxy table. 

This update will:
- Add a new serverstatus to the tripal_galaxy table
- Add 'disable all workflows'/'enable all workflows' to the admin/tripal/extension/galaxy form for each of the servers listed. Enable all workflows will only appear if at least one of the workflows associated with that specific galaxy instance is disabled.
- Add an 'enable'/'disable' button to each workflow found on admin/tripal/extension/galaxy/workflows
- Update the serverstatus when the test button is clicked on admin/tripal/extension/galaxy, so that if the server is down the serverstatus is accurate.
- A task within the existing cron run has been added to check the server status every 24 hours.


