### PR TITLE
Display annotation with markup component

### DIFF
--- a/includes/tripal_galaxy.webform.inc
+++ b/includes/tripal_galaxy.webform.inc
@@ -95,9 +95,8 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
       'name' => 'workflow step annotation',
       'type' => 'markup',
       'value' => '<div class="workflow-step-annotation">' .
-        '<h3>Instruction:' .
-        $step_annotation .
-        '</h3></div>',
+        '<h3>Instruction:</h3>h3>' .
+        $step_annotation . '</div>',
       'extra' => [
         'description' => '',
         'description_above' => 1,

--- a/includes/tripal_galaxy.webform.inc
+++ b/includes/tripal_galaxy.webform.inc
@@ -92,7 +92,7 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
       'cid' => $dcid,
       'pid' => $cid,
       'form_key' => $fieldset_key,
-      'name' => '',
+      'name' => 'workflow step annotation',
       'type' => 'markup',
       'value' => $step_annotation,
       'extra' => [

--- a/includes/tripal_galaxy.webform.inc
+++ b/includes/tripal_galaxy.webform.inc
@@ -73,7 +73,7 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
       'type' => 'fieldset',
       'value' => '',
       'extra' => [
-        'description' => $step_annotation,
+        'description' => '',
         'description_above' => 1,
         'private' => 0,
         'css_classes' => 'tripal-galaxy-fieldset',
@@ -85,6 +85,24 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
       'weight' => $cid,
     ];
 
+    // add a markup component to display annotation from each step from galaxy workflow.
+    $dcid = count($webform->components) + 1;
+    $webform->components[] = [
+      'cid' => $dcid,
+      'pid' => $cid,
+      'form_key' => $fieldset_key,
+      'name' => '',
+      'type' => 'markup',
+      'value' => $step_annotation,
+      'extra' => [
+        'description' => '',
+        'description_above' => 1,
+        'private' => 0,
+        'title_display' => 0,
+      ],
+      'required' => '0',
+      'weight' => $cid,
+    ];
 
     $fieldset_cid = count($webform->components);
 

--- a/includes/tripal_galaxy.webform.inc
+++ b/includes/tripal_galaxy.webform.inc
@@ -84,6 +84,7 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
       'required' => '0',
       'weight' => $cid,
     ];
+    $fieldset_cid = count($webform->components);
 
     // add a markup component to display annotation from each step from galaxy workflow.
     $dcid = count($webform->components) + 1;
@@ -104,7 +105,6 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
       'weight' => $cid,
     ];
 
-    $fieldset_cid = count($webform->components);
 
     // Handle the step type. So far we only know about 'data_input' and 'tool'.
     // The succeeding tool to the

--- a/includes/tripal_galaxy.webform.inc
+++ b/includes/tripal_galaxy.webform.inc
@@ -94,7 +94,10 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
       'form_key' => $fieldset_key,
       'name' => 'workflow step annotation',
       'type' => 'markup',
-      'value' => $step_annotation,
+      'value' => '<div class="workflow-step-annotation">' .
+        '<h3>Instruction:' .
+        $step_annotation .
+        '</h3></div>',
       'extra' => [
         'description' => '',
         'description_above' => 1,

--- a/includes/tripal_galaxy.webform.inc
+++ b/includes/tripal_galaxy.webform.inc
@@ -95,7 +95,7 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
       'name' => 'workflow step annotation',
       'type' => 'markup',
       'value' => '<div class="workflow-step-annotation">' .
-        '<h3>Instruction:</h3>h3>' .
+        '<h3>Instruction:</h3>' .
         $step_annotation . '</div>',
       'extra' => [
         'description' => '',

--- a/includes/tripal_galaxy.webform.inc
+++ b/includes/tripal_galaxy.webform.inc
@@ -100,6 +100,7 @@ function tripal_galaxy_build_webform($galaxy_id, $workflow_id) {
         'description_above' => 1,
         'private' => 0,
         'title_display' => 0,
+        'format' => 'full_html',
       ],
       'required' => '0',
       'weight' => $cid,

--- a/theme/css/tripal_galaxy.css
+++ b/theme/css/tripal_galaxy.css
@@ -23,3 +23,8 @@
   white-space: nowrap;
   overflow: hidden;
 }
+
+.workflow-step-annotation {
+  background: #F8FFF1;
+  padding: 2px 2px 2px 10px;
+}

--- a/theme/css/tripal_galaxy.css
+++ b/theme/css/tripal_galaxy.css
@@ -23,7 +23,3 @@
   white-space: nowrap;
   overflow: hidden;
 }
-
-.tripal-galaxy-fieldset .fieldset-description {
-  color: #0099ff;
-}


### PR DESCRIPTION
This PR adds a markup component to each workflow step. It extracts the annotation from galaxy workflow directly and displays it at each step. With this PR, we can add instructions to each step from within Galaxy and display them on the Tripal site. The annotation accepts full HTML string.

 **Annotation from galaxy**
<img width="1094" alt="screen shot 2018-05-25 at 11 41 52 am" src="https://user-images.githubusercontent.com/1262709/40553586-18b6c13c-6011-11e8-98af-7ca55670a50a.png">

**Annotation shows on tripal site**
<img width="1287" alt="screen shot 2018-05-25 at 11 39 55 am" src="https://user-images.githubusercontent.com/1262709/40553592-1ba1e23c-6011-11e8-9ceb-c0fc69f696e4.png">

