### PR TITLE
fix empty option value for select type input

### DIFF
--- a/api/tripal_galaxy.api.inc
+++ b/api/tripal_galaxy.api.inc
@@ -560,6 +560,14 @@ function tripal_galaxy_invoke_workflow($sid, $job = NULL) {
     if (!$value) {
       continue;
     }
+
+    if ($value == $step_index) {
+      // if $value == $step_index, it means the input value is empty.
+      // (see line 656: $extra['items'] .= $step['id'] . "|" . $val[0] . "\n"; in tripal_galaxy.webform.inc
+      // Some tools accept empty input as valid input (e.g., the Galaxy hisat2 tool), we should not skip this value.
+      // let's change the value from $step_index back to empty.
+      $value = '';
+    }
     if (!array_key_exists($step_index, $parameters)) {
       $parameters[$step_index] = [];
     }


### PR DESCRIPTION
In some situations, **empty** is a valid option value for a select type input, see the hisat2 tool:

<img width="930" alt="screen shot 2018-09-28 at 4 34 11 pm" src="https://user-images.githubusercontent.com/1262709/46232232-7ac53a00-c33c-11e8-8440-a23a02579a90.png">

Currently, tripal galaxy module replaces the empty value with the **step id** when building up the tool input component, see https://github.com/tripal/tripal_galaxy/blob/7.x-1.x/includes/tripal_galaxy.webform.inc#L655~#L657. This is problematic for the hisat2 tool in which empty value option is valid. To reproduce this issue, use the following workflow:

[mapping-hisat2-single-end.ga.zip](https://github.com/tripal/tripal_galaxy/files/2429668/mapping-hisat2-single-end.ga.zip)

At step 6, select **Unstranded** for **Specify strand information**

<img width="744" alt="screen shot 2018-09-28 at 4 41 33 pm" src="https://user-images.githubusercontent.com/1262709/46232534-79e0d800-c33d-11e8-8fd6-05e27ed2b8c8.png">.

You will be able to invoke the workflow, but the workflow will not proceed after all data have been uploaded to Galaxy.

This PR fix this issue.


