### PR TITLE
Tripal galaxy submission status emails -- fix to stop repeated sending of notification emails

### DIFF
--- a/api/tripal_galaxy.api.inc
+++ b/api/tripal_galaxy.api.inc
@@ -107,6 +107,7 @@ function tripal_galaxy_check_submission_status($sid = false, $force = FALSE) {
       'sid',
       'submit_date',
       'status',
+      'email',
     ]);
     $query->join('tripal_galaxy_workflow', 'tgw', 'tgw.galaxy_workflow_id = tgws.galaxy_workflow_id');
     $query->fields('tgw', ['galaxy_id', 'workflow_id', 'nid']);
@@ -121,6 +122,7 @@ function tripal_galaxy_check_submission_status($sid = false, $force = FALSE) {
       'sid',
       'submit_date',
       'status',
+      'email',
     ]);
     $query->join('tripal_galaxy_workflow', 'tgw', 'tgw.galaxy_workflow_id = tgws.galaxy_workflow_id');
     $query->fields('tgw', ['galaxy_id', 'workflow_id', 'nid']);
@@ -229,8 +231,8 @@ function tripal_galaxy_check_submission_status($sid = false, $force = FALSE) {
 
   // Now inform the user that the job is done!
     $end_time = $update_time->getTimestamp();
-    if (!$force) {
-      tripal_galaxy_send_submission_ended_mail($sid, $node->uid);
+    if (!$force && $submission->email != 'SENT') {
+      tripal_galaxy_send_submission_ended_mail($submission->sid, $node->uid);
     }
 
     $fields = [

--- a/api/tripal_galaxy.api.inc
+++ b/api/tripal_galaxy.api.inc
@@ -138,6 +138,10 @@ function tripal_galaxy_check_submission_status($sid = false, $force = FALSE) {
     if (!$submission->invocation_id) {
       continue;
     }
+    // If the job is complete skip it.
+    if ($submission->status == 'Completed') {
+      continue;
+    }
       // Get the node for this submission.
     $node = node_load($submission->nid);
 
@@ -314,10 +318,15 @@ function tripal_galaxy_get_history_name($submission, $node) {
  *   The ID of the history into which the workflow should be executed.
  * @param $sid
  *    The unique identified from the tripal_galaxy_workflow_submission table.
+ *  @param $uid
+ *    The user id of the person who submitted the workflow.
  */
 function tripal_galaxy_invoke_workflow($galaxy, $workflow_id, $parameters, 
-  $inputs, $history_id, $sid) {
-
+  $inputs, $history_id, $sid, $uid) {
+  
+    // Get the node for this submission.
+  $node = node_load($submission->nid);
+  
   // Invoke the workflow and check for errors
   $gworkflows = new GalaxyWorkflows($galaxy);
   $params = [
@@ -338,7 +347,7 @@ function tripal_galaxy_invoke_workflow($galaxy, $workflow_id, $parameters,
       ])
       ->condition('sid', $sid)
       ->execute();
-    tripal_galaxy_send_submission_failed_mail($submission->sid, $node->uid);
+    tripal_galaxy_send_submission_failed_mail($submission->sid, $uid);
   }
   else {
     db_update('tripal_galaxy_workflow_submission')
@@ -350,7 +359,7 @@ function tripal_galaxy_invoke_workflow($galaxy, $workflow_id, $parameters,
       ])
       ->condition('sid', $sid)
       ->execute();
-    tripal_galaxy_send_submission_start_mail($submission->sid, $node->uid);
+    tripal_galaxy_send_submission_start_mail($submission->sid, $uid);
   }
 
 }

--- a/includes/tripal_galaxy.webform.inc
+++ b/includes/tripal_galaxy.webform.inc
@@ -1390,7 +1390,7 @@ function tripal_galaxy_invoke_webform_submission($sid, $job = NULL) {
   
   // Call the Tripal Galaxy API function to invoke this workflow.
   tripal_galaxy_invoke_workflow($galaxy, $submission->workflow_id, $parameters, 
-    $input_datasets, $history['id'], $sid);
+    $input_datasets, $history['id'], $sid, $node->uid);
 }
 
 /**

--- a/tripal_galaxy.install
+++ b/tripal_galaxy.install
@@ -126,6 +126,11 @@ function tripal_galaxy_add_workflow_submission_table(&$schema){
         'length' => 128,
         'description' => 'Galaxy provides an invocation ID that can be used ' .
           'to check the status of a submitted workflow.'
+      ),
+      'email' => array(
+        'type' => 'varchar',
+        'length' => 128,
+        'description' => 'Flag if notification email has been sent'
       )
     ),
     'indexes' => array(
@@ -438,6 +443,24 @@ function tripal_galaxy_update_7104() {
       $error = $e->getMessage();
       throw new DrupalUpdateException('Could not update the tripal_galaxy table: ' . $error);
     }
+  } catch (\PDOException $e) {
+    $error = $e->getMessage();
+    throw new DrupalUpdateException('Could not update the tripal_galaxy table: ' . $error);
+  }
+}
+
+/**
+ * This update adds the email column to the tripal_galaxy_workflow submission table.
+ */
+function tripal_galaxy_update_7106()
+{
+  try {
+    $email = array(
+      'type' => 'varchar',
+      'length' => 128,
+      'description' => 'Flag if notification email has been sent',
+    );
+    db_add_field('tripal_galaxy_workflow_submission', 'email', $email);
   } catch (\PDOException $e) {
     $error = $e->getMessage();
     throw new DrupalUpdateException('Could not update the tripal_galaxy table: ' . $error);

--- a/tripal_galaxy.module
+++ b/tripal_galaxy.module
@@ -1411,8 +1411,19 @@ function tripal_galaxy_send_submission_ended_mail($sid, $uid) {
   // message delivery; only that there were no PHP-related issues encountered
   // while sending.
   $result = drupal_mail($module, $key, $to, $language, $params, $from, $send);
+
   if ($result['result'] != TRUE) {
+    db_update('tripal_galaxy_workflow_submission')
+      ->fields(array('email' => 'SENT', ))
+      ->condition('sid', $sid)
+      ->execute();
     watchdog('tripal_galaxy', t('There was a problem sending your message and it was not sent.'), [], WATCHDOG_ERROR);
+  }
+  else {
+    db_update('tripal_galaxy_workflow_submission')
+      ->fields(['email' => 'SENT', ])
+      ->condition('sid', $sid)
+      ->execute();
   }
 }
 
@@ -1453,6 +1464,12 @@ function tripal_galaxy_send_submission_failed_mail($sid, $uid) {
   $result = drupal_mail($module, $key, $to, $language, $params, $from, $send);
   if ($result['result'] != TRUE) {
     watchdog('tripal_galaxy', t('There was a problem sending your message and it was not sent.'), [], WATCHDOG_ERROR);
+  } 
+  else {
+    db_update('tripal_galaxy_workflow_submission')
+      ->fields(['email' => 'SENT', ])
+      ->condition('sid', $sid)
+      ->execute();
   }
 }
 


### PR DESCRIPTION
This update addes a new column to the tripal_galaxy_workflow_submission table to allow for recording of whether or not a notification email has been sent to the user letting them know their submission has completed.

To test you will need to run a drush updatedb before testing by calling the submission status drush call (trp_galaxy_status). Check that the status of 'email' column shows all emails have been sent. You might receive a lot of emails the first time since the information is currently not recorded but after the initial run it should be only send out emails to users who have not been notified that their workflow has completed.